### PR TITLE
Add Supply  Current Limits on Drivetrain

### DIFF
--- a/src/main/java/frc/robot/constants/DrivetrainConstants.java
+++ b/src/main/java/frc/robot/constants/DrivetrainConstants.java
@@ -4,14 +4,18 @@
 
 package frc.robot.constants;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
+import static edu.wpi.first.units.Units.Seconds;
 
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.util.Units;
+import edu.wpi.first.units.measure.Current;
+import edu.wpi.first.units.measure.Time;
 import frc.robot.generated.TunerConstants;
 
 /** Add your docs here. */
@@ -25,4 +29,9 @@ public class DrivetrainConstants {
   public static final double currentLimit = 60;
   public static final double autoMaxSpeedMetersPerSecond = maxSpeedMetersPerSecond * 0.8;
   public static final double estimatedKp = 12/(maxSpeedMetersPerSecond/ (TunerConstants.kWheelRadius.in(Meters) * 2 * Math.PI));
+  public class CurrentLimits {
+    public static final Current kDriveCurrentLimitMax = Amps.of(70); //Max draw allowed
+    public static final Current  kDriveCurrentLimitMin = Amps.of(40); //Motor drops to min after hitting ma
+    public static final Time kDriveCurrentDuration = Seconds.of(0.25); //Time to hold at min current
+  }
 }


### PR DESCRIPTION
## Description of Changes
Add Supply  Current Limits on Drivetrain drive motors to avoid drive browning out

Constants in unit type are added to DrivetrainConstants.

## Checklist:
<!--Put an 'x' in all of the boxes to assure following guidance.-->
- [x ] I have performed a self-review of my own code
- [x ] I have made corresponding changes to the documentation
- [x ] I have [squashed related commits][1]

[1]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html