### PR TITLE
Add Supply  Current Limits on Drivetrain

### DIFF
--- a/src/main/java/frc/robot/constants/DrivetrainConstants.java
+++ b/src/main/java/frc/robot/constants/DrivetrainConstants.java
@@ -4,14 +4,18 @@
 
 package frc.robot.constants;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
+import static edu.wpi.first.units.Units.Seconds;
 
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.util.Units;
+import edu.wpi.first.units.measure.Current;
+import edu.wpi.first.units.measure.Time;
 import frc.robot.generated.TunerConstants;
 
 /** Add your docs here. */
@@ -25,4 +29,9 @@ public class DrivetrainConstants {
   public static final double currentLimit = 60;
   public static final double autoMaxSpeedMetersPerSecond = maxSpeedMetersPerSecond * 0.8;
   public static final double estimatedKp = 12/(maxSpeedMetersPerSecond/ (TunerConstants.kWheelRadius.in(Meters) * 2 * Math.PI));
+  public class CurrentLimits {
+    public static final Current kDriveCurrentLimitMax = Amps.of(70); //Max draw allowed
+    public static final Current  kDriveCurrentLimitMin = Amps.of(40); //Motor drops to min after hitting ma
+    public static final Time kDriveCurrentDuration = Seconds.of(0.25); //Time to hold at min current
+  }
 }

--- a/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -6,7 +6,13 @@ import java.util.function.Supplier;
 
 import com.ctre.phoenix6.SignalLogger;
 import com.ctre.phoenix6.Utils;
+import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.configs.TalonFXConfigurator;
+import com.ctre.phoenix6.hardware.CANcoder;
+import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.swerve.SwerveDrivetrainConstants;
+import com.ctre.phoenix6.swerve.SwerveModule;
 import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
 import com.ctre.phoenix6.swerve.SwerveModuleConstants;
 import com.ctre.phoenix6.swerve.SwerveRequest;
@@ -25,7 +31,9 @@ import edu.wpi.first.wpilibj2.command.Subsystem;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.constants.ControllerConstants;
 import frc.robot.constants.DrivetrainConstants;
+import frc.robot.constants.DrivetrainConstants.CurrentLimits;
 import frc.robot.generated.TunerConstants.TunerSwerveDrivetrain;
+import static frc.robot.constants.DrivetrainConstants.*;
 
 /**
  * Class that extends the Phoenix 6 SwerveDrivetrain class and implements
@@ -134,6 +142,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
         if (Utils.isSimulation()) {
             startSimThread();
         }
+        applySupplyCurrentLimits();
     }
 
     /**
@@ -158,6 +167,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
         if (Utils.isSimulation()) {
             startSimThread();
         }
+        applySupplyCurrentLimits();
     }
 
     /**
@@ -190,8 +200,27 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
         if (Utils.isSimulation()) {
             startSimThread();
         }
+        applySupplyCurrentLimits();
     }
 
+    /**
+     * Sets Supply Current Limits for the drive motors based on the values in DrivetrainConstants.
+     */
+    private void applySupplyCurrentLimits(){
+        // Set current limits for the drive motors
+        for (SwerveModule<TalonFX, TalonFX, CANcoder> module : getModules()) {
+            TalonFXConfigurator configurator = module.getDriveMotor().getConfigurator();
+            TalonFXConfiguration config  = new TalonFXConfiguration();
+            // Get the current limits from the constants to avoid wipe out of existing values we don't set
+            module.getDriveMotor().getConfigurator().refresh(config);
+            CurrentLimitsConfigs currentLimitConfigs = config.CurrentLimits;
+            currentLimitConfigs.withSupplyCurrentLowerLimit(CurrentLimits.kDriveCurrentLimitMin)
+                .withSupplyCurrentLimit(CurrentLimits.kDriveCurrentLimitMax) 
+                .withSupplyCurrentLowerTime(CurrentLimits.kDriveCurrentDuration) 
+                .withSupplyCurrentLimitEnable(true);
+            configurator.apply(config);
+        }
+    }
     /**
      * Returns a command that applies the specified control request to this swerve drivetrain.
      *


### PR DESCRIPTION
Add Supply  Current Limits on Drivetrain drive motors to avoid drive browning out

Constants in unit type are added to DrivetrainConstants.

## Description of Changes
<!--Describe (in detail) the changes in the pull request here.-->

## Checklist:
<!--Put an 'x' in all of the boxes to assure following guidance.-->
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have [squashed related commits][1]

[1]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html