### PR TITLE
Add apriltag constants for blue and red fields

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-* @poloka @bradmongar
+* @poloka @bradmongar @CarlYarwood

--- a/src/main/java/frc/robot/constants/ApriltagConstants.java
+++ b/src/main/java/frc/robot/constants/ApriltagConstants.java
@@ -1,0 +1,43 @@
+package frc.robot.constants;
+
+// https://firstfrc.blob.core.windows.net/frc2025/FieldAssets/Apriltag_Images_and_User_Guide.pdf
+public final class ApriltagConstants {
+  enum Blue {
+    LEFT_CORAL_STATION(13),
+    RIGHT_CORAL_STATION(12),
+    PROCESSOR(16),
+    LEFT_BARGE(14),
+    RIGHT_BARGE(15),
+    REEF_1(18),
+    REEF_2(19),
+    REEF_3(20),
+    REEF_4(21),
+    REEF_5(22),
+    REEF_6(17);
+
+    public final int id;
+
+    Blue(final int id){
+      this.id = id;
+    }
+  }
+  enum Red {
+    LEFT_CORAL_STATION(1),
+    RIGHT_CORAL_STATION(2),
+    PROCESSOR(3),
+    LEFT_BARGE(5),
+    RIGHT_BARGE(4),
+    REEF_1(7),
+    REEF_2(6),
+    REEF_3(11),
+    REEF_4(10),
+    REEF_5(9),
+    REEF_6(8);
+
+    public final int id;
+
+    Red(final int id){
+      this.id = id;
+    }
+  }
+}


### PR DESCRIPTION
## Description of Changes
Adding the apriltag constants for the blue and red sides of the field.  

## References
* https://firstfrc.blob.core.windows.net/frc2025/FieldAssets/Apriltag_Images_and_User_Guide.pdf

## Checklist:
<!--Put an 'x' in all of the boxes to assure following guidance.-->
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have [squashed related commits][1]

[1]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html